### PR TITLE
Handle oneOf keywords

### DIFF
--- a/plugin/src/main/scala/com/github/eikek/sbt/openapi/OpenApiSchema.scala
+++ b/plugin/src/main/scala/com/github/eikek/sbt/openapi/OpenApiSchema.scala
@@ -116,15 +116,15 @@ object OpenApiSchema extends AutoPlugin {
   }
 
   def groupDiscriminantSchemas(allSchemas: Seq[SingularSchemaClass]): Seq[SchemaClass] = {
-    val discriminantSchemasMap = allSchemas.filter(_.discriminatorRef.isDefined).groupBy(_.discriminatorRef.get)
-    val discriminantSchemas = discriminantSchemasMap.map { case (k, v) =>
-      val topLevelDiscriminant = allSchemas.collectFirst { case ssc if ssc.name == k => ssc }.get
+    val discriminantSchemasMap = allSchemas.filter(_.allOfRef.isDefined).groupBy(_.allOfRef.get)
+    val discriminantSchemas = discriminantSchemasMap.map { case (allOfRef, childSchemas) =>
+      val allOfRoot = allSchemas.collectFirst { case ssc if ssc.name == allOfRef => ssc }.get
       DiscriminantSchemaClass(
-        topLevelDiscriminant.name,
-        topLevelDiscriminant.properties,
-        topLevelDiscriminant.doc,
-        topLevelDiscriminant.wrapper,
-        v.toList
+        allOfRoot.name,
+        allOfRoot.properties,
+        allOfRoot.doc,
+        allOfRoot.wrapper,
+        childSchemas.toList
       )
     }.toSeq
 

--- a/plugin/src/main/scala/com/github/eikek/sbt/openapi/OpenApiSchema.scala
+++ b/plugin/src/main/scala/com/github/eikek/sbt/openapi/OpenApiSchema.scala
@@ -115,7 +115,15 @@ object OpenApiSchema extends AutoPlugin {
     files
   }
 
-  def groupDiscriminantSchemas(allSchemas: Seq[SingularSchemaClass]): Seq[SchemaClass] = {
+  def groupDiscriminantSchemas(parserResult: Seq[SingularSchemaClass]): Seq[SchemaClass] = {
+    val allSchemas = parserResult.map { ssc =>
+      val referencing = parserResult.find(_.oneOfRef.contains(ssc.name))
+      referencing match {
+        case Some(ref) => ssc.copy(allOfRef = Some(ref.name))
+        case None => ssc
+      }
+    }
+
     val discriminantSchemasMap = allSchemas.filter(_.allOfRef.isDefined).groupBy(_.allOfRef.get)
     val discriminantSchemas = discriminantSchemasMap.map { case (allOfRef, childSchemas) =>
       val allOfRoot = allSchemas.collectFirst { case ssc if ssc.name == allOfRef => ssc }.get

--- a/plugin/src/main/scala/com/github/eikek/sbt/openapi/impl/Parser.scala
+++ b/plugin/src/main/scala/com/github/eikek/sbt/openapi/impl/Parser.scala
@@ -39,7 +39,7 @@ object Parser {
               None
           }
         }
-        SingularSchemaClass(name, allProperties.toList.flatten, Doc(cs.getDescription.nullToEmpty), discriminatorRef = discriminatorOpt)
+        SingularSchemaClass(name, allProperties.toList.flatten, Doc(cs.getDescription.nullToEmpty), allOfRef = discriminatorOpt)
       case s if s.getProperties != null =>
         val required = Option(s.getRequired).map(_.asScala.toSet).getOrElse(Set.empty)
         val discriminatorName = Option(s.getDiscriminator).map(_.getPropertyName)

--- a/plugin/src/main/scala/com/github/eikek/sbt/openapi/impl/SchemaClass.scala
+++ b/plugin/src/main/scala/com/github/eikek/sbt/openapi/impl/SchemaClass.scala
@@ -12,7 +12,7 @@ trait SchemaClass {
 case class SingularSchemaClass(name: String
                                , properties: List[Property] = Nil
                                , doc: Doc = Doc.empty
-                               , wrapper: Boolean = false, allOfRef: Option[String] = None) extends SchemaClass {
+                               , wrapper: Boolean = false, allOfRef: Option[String] = None, oneOfRef: List[String] = Nil) extends SchemaClass {
   def +(p: Property): SingularSchemaClass =
     copy(properties = p :: properties)
 

--- a/plugin/src/main/scala/com/github/eikek/sbt/openapi/impl/SchemaClass.scala
+++ b/plugin/src/main/scala/com/github/eikek/sbt/openapi/impl/SchemaClass.scala
@@ -12,7 +12,7 @@ trait SchemaClass {
 case class SingularSchemaClass(name: String
                                , properties: List[Property] = Nil
                                , doc: Doc = Doc.empty
-                               , wrapper: Boolean = false, discriminatorRef: Option[String] = None) extends SchemaClass {
+                               , wrapper: Boolean = false, allOfRef: Option[String] = None) extends SchemaClass {
   def +(p: Property): SingularSchemaClass =
     copy(properties = p :: properties)
 
@@ -57,7 +57,7 @@ object SchemaClass {
 
   private def resolveFieldImports(src: SourceFile): SourceFile =
     src.fields.map(_.typeDef).
-      foldLeft(src){ (s, td) =>
+      foldLeft(src) { (s, td) =>
         s.addImports(td.imports)
       }
 }

--- a/plugin/src/test/scala/com/github/eikek/sbt/openapi/OpenApiSchemaSpec.scala
+++ b/plugin/src/test/scala/com/github/eikek/sbt/openapi/OpenApiSchemaSpec.scala
@@ -7,8 +7,8 @@ object OpenApiSchemaSpec extends SimpleTestSuite {
 
   test("Separating schemas") {
     val startingSchemas = Seq(
-      SingularSchemaClass("Foo", List(Property("thisIsAString", Type.String), Property("anotherField", Type.Int32)), discriminatorRef = Some("Stuff")),
-      SingularSchemaClass("Bar", List(Property("barField", Type.String), Property("newBool", Type.Bool)), discriminatorRef = Some("Stuff")),
+      SingularSchemaClass("Foo", List(Property("thisIsAString", Type.String), Property("anotherField", Type.Int32)), allOfRef = Some("Stuff")),
+      SingularSchemaClass("Bar", List(Property("barField", Type.String), Property("newBool", Type.Bool)), allOfRef = Some("Stuff")),
       SingularSchemaClass("Stuff", List(Property("type", Type.String, false, discriminator = true))),
       SingularSchemaClass("SingularThing", List(Property("first", Type.String), Property("second", Type.Bool)))
     )
@@ -17,8 +17,8 @@ object OpenApiSchemaSpec extends SimpleTestSuite {
     val expectedSchemas = Seq(
       SingularSchemaClass("SingularThing", List(Property("first", Type.String), Property("second", Type.Bool))),
       DiscriminantSchemaClass("Stuff", List(Property("type", Type.String, false, discriminator = true)), subSchemas = List(
-        SingularSchemaClass("Foo", List(Property("thisIsAString", Type.String), Property("anotherField", Type.Int32)), discriminatorRef = Some("Stuff")),
-        SingularSchemaClass("Bar", List(Property("barField", Type.String), Property("newBool", Type.Bool)), discriminatorRef = Some("Stuff"))
+        SingularSchemaClass("Foo", List(Property("thisIsAString", Type.String), Property("anotherField", Type.Int32)), allOfRef = Some("Stuff")),
+        SingularSchemaClass("Bar", List(Property("barField", Type.String), Property("newBool", Type.Bool)), allOfRef = Some("Stuff"))
       ))
     )
 

--- a/plugin/src/test/scala/com/github/eikek/sbt/openapi/ParserSpec.scala
+++ b/plugin/src/test/scala/com/github/eikek/sbt/openapi/ParserSpec.scala
@@ -12,7 +12,7 @@ object ParserSpec extends SimpleTestSuite {
     val actual = schema("DiscriminatorObject")
 
     assertEquals(actual.name,"DiscriminatorObject")
-    assertEquals(actual.discriminatorRef, None)
+    assertEquals(actual.allOfRef, None)
     val propsWithNoDocs: Set[Property] = actual.properties.map(_.copy(doc = Doc.empty)).toSet
     assertEquals(propsWithNoDocs, Set(
       Property("type", Type.String, false, None, None, Doc.empty, true),
@@ -28,7 +28,7 @@ object ParserSpec extends SimpleTestSuite {
     val actual = schema("FirstDiscriminatorSubObject")
 
     assertEquals(actual.name,"FirstDiscriminatorSubObject")
-    assertEquals(actual.discriminatorRef, Some("DiscriminatorObject"))
+    assertEquals(actual.allOfRef, Some("DiscriminatorObject"))
     val propsWithNoDocs: Set[Property] = actual.properties.map(_.copy(doc = Doc.empty)).toSet
     assertEquals(propsWithNoDocs, Set(
       Property("uniqueString", Type.String, true, None, None, Doc.empty, false)
@@ -42,7 +42,7 @@ object ParserSpec extends SimpleTestSuite {
     val actual = schema("SecondDiscriminatorObject")
 
     assertEquals(actual.name,"SecondDiscriminatorObject")
-    assertEquals(actual.discriminatorRef, Some("DiscriminatorObject"))
+    assertEquals(actual.allOfRef, Some("DiscriminatorObject"))
     val propsWithNoDocs: Set[Property] = actual.properties.map(_.copy(doc = Doc.empty)).toSet
     assertEquals(propsWithNoDocs, Set(
       Property("uniqueInteger", Type.Int32, false, None, None, Doc.empty, false),
@@ -57,7 +57,7 @@ object ParserSpec extends SimpleTestSuite {
     val actual = schema("Room")
 
     assertEquals(actual.name,"Room")
-    assertEquals(actual.discriminatorRef, None)
+    assertEquals(actual.allOfRef, None)
     val propsWithNoDocs: Set[Property] = actual.properties.map(_.copy(doc = Doc.empty)).toSet
     assertEquals(propsWithNoDocs, Set(
       Property("name", Type.String, false, None, None, Doc.empty, false),

--- a/plugin/src/test/scala/com/github/eikek/sbt/openapi/impl/ScalaCodeSpec.scala
+++ b/plugin/src/test/scala/com/github/eikek/sbt/openapi/impl/ScalaCodeSpec.scala
@@ -12,8 +12,8 @@ object ScalaCodeSpec extends SimpleTestSuite {
         Property("type", Type.String, discriminator = true)
       ),
       subSchemas = List(
-        SingularSchemaClass("Foo", List(Property("thisIsAString", Type.String), Property("anotherField", Type.Int32)), discriminatorRef = Some("Stuff")),
-        SingularSchemaClass("Bar", List(Property("barField", Type.String), Property("newBool", Type.Bool)), discriminatorRef = Some("Stuff"))
+        SingularSchemaClass("Foo", List(Property("thisIsAString", Type.String), Property("anotherField", Type.Int32)), allOfRef = Some("Stuff")),
+        SingularSchemaClass("Bar", List(Property("barField", Type.String), Property("newBool", Type.Bool)), allOfRef = Some("Stuff"))
       )
     )
 


### PR DESCRIPTION
Thanks to https://github.com/eikek/sbt-openapi-schema/pull/8, sbt-openapi is able to parse `allOf` declarations and transform them in `sealed trait` hierarchies. 

However, it is still not able to handle other keywords such as `anyOf` or `not` or `oneOf` (https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/). Hence, a `NullPointerException` is thrown while trying to do so as the plugin always tries to get the `allOf` value of a `ComposedSchema`.

This pull request consists in handling the `oneOf` keywords by converting it in a `allOf` definition after having parsed the swagger file.