### PR TITLE
Add missing imports for sub-schemas

### DIFF
--- a/plugin/src/main/scala/com/github/eikek/sbt/openapi/impl/SchemaClass.scala
+++ b/plugin/src/main/scala/com/github/eikek/sbt/openapi/impl/SchemaClass.scala
@@ -65,6 +65,7 @@ object SchemaClass {
       internalSchemas = internalSchemas
     ).modify(cm.changeSource)
       .modify(s => s.addImports(Imports.flatten(s.parents.map(_.imports))))
+      .modify(s => s.addImports(Imports.flatten(s.internalSchemas.map(_.imports))))
       .modify(resolveFieldImports)
   }
 


### PR DESCRIPTION
There was an issue for Scala code generation for `oneOf` keyword, the imports were not added to the generated file.

This PR fixes this issue.