### PR TITLE
Fix building static docs with redocly

### DIFF
--- a/plugin/src/main/scala/com/github/eikek/sbt/openapi/OpenApiSchema.scala
+++ b/plugin/src/main/scala/com/github/eikek/sbt/openapi/OpenApiSchema.scala
@@ -203,7 +203,7 @@ object OpenApiSchema extends AutoPlugin {
   ): File = {
     logger.info("Generating static documentation for openapi spec via redoc…")
     val outFile = out / "index.html"
-    val cmd = redoclyCmd ++ Seq("bundle", openapi.toString, "-o", outFile.toString)
+    val cmd = redoclyCmd ++ Seq("build-docs", openapi.toString, "-o", outFile.toString)
     Sys(logger).execSuccess(cmd)
     if (!out.exists) {
       sys.error("Generation did not produce a file")


### PR DESCRIPTION
The sub command changed to `build-docs`